### PR TITLE
kernel: implement mplay_ipaddress()

### DIFF
--- a/gm8emulator/src/gml.rs
+++ b/gm8emulator/src/gml.rs
@@ -4,6 +4,7 @@ pub mod datetime;
 pub mod ds;
 pub mod file;
 pub mod kernel;
+pub mod network;
 pub mod rand;
 pub mod runtime;
 pub mod value;

--- a/gm8emulator/src/gml/kernel.rs
+++ b/gm8emulator/src/gml/kernel.rs
@@ -12,7 +12,7 @@ use crate::{
         self,
         compiler::mappings,
         datetime::{self, DateTime},
-        ds, file, Context, Value,
+        ds, file, network, Context, Value,
     },
     instance::{DummyFieldHolder, Field, Instance, InstanceState},
     math::Real,
@@ -6777,9 +6777,9 @@ impl Game {
         unimplemented!("Called unimplemented kernel function mplay_message_clear")
     }
 
-    pub fn mplay_ipaddress(&mut self, _context: &mut Context, _args: &[Value]) -> gml::Result<Value> {
-        // Expected arg count: 0
-        unimplemented!("Called unimplemented kernel function mplay_ipaddress")
+    pub fn mplay_ipaddress(&mut self, _context: &mut Context, args: &[Value]) -> gml::Result<Value> {
+        expect_args!(args, [])?;
+        Ok(network::get_local_ip().unwrap_or([127,0,0,1].into()).to_string().into())
     }
 
     pub fn event_inherited(&mut self, context: &mut Context, args: &[Value]) -> gml::Result<Value> {

--- a/gm8emulator/src/gml/kernel.rs
+++ b/gm8emulator/src/gml/kernel.rs
@@ -6779,7 +6779,7 @@ impl Game {
 
     pub fn mplay_ipaddress(&mut self, _context: &mut Context, args: &[Value]) -> gml::Result<Value> {
         expect_args!(args, [])?;
-        Ok(network::get_local_ip().unwrap_or([127,0,0,1].into()).to_string().into())
+        Ok(network::get_local_ip().unwrap_or(std::net::Ipv4Addr::LOCALHOST.into()).to_string().into())
     }
 
     pub fn event_inherited(&mut self, context: &mut Context, args: &[Value]) -> gml::Result<Value> {

--- a/gm8emulator/src/gml/network.rs
+++ b/gm8emulator/src/gml/network.rs
@@ -1,0 +1,51 @@
+use std::{io, net};
+
+pub fn get_local_ip() -> io::Result<net::IpAddr> {
+    // For the meaning of 0.0.0.0, see 'INADDR_ANY'. Port 0 states that we don't expect any
+    // response (RFC 768), so the operating system is allowed to select any ephemeral port.
+    let socket = match net::UdpSocket::bind(net::SocketAddr::from(([0,0,0,0], 0))) {
+        Ok(s) => s,
+        Err(e) => return Err(e),
+    };
+
+    // Seems to work anyway even with default 'false', so we do this just in case.
+    let _ = socket.set_broadcast(true);
+
+    // Obtain an ephemeral port number that the operating system could provide us. It may
+    // be outside of the standard IANA range 49152..65535 for ephemeral ports, but we don't
+    // check for this because the operating system knows more and better, and we trust it.
+    let port = match socket.local_addr() {
+        Ok(a) => a.port(),
+        Err(_) => 0,  // this works too at least on Windows 7, so let's try
+    };
+
+    // We're binding socket to INADDR_ANY, so it's necessary to specify a peer in order to
+    // obtain something other than 0.0.0.0 from the result of .local_addr() (which actually
+    // calls getsockname() under the hood). Since the members of our network are unknown to
+    // us, host addresses reserved for broadcasting (see e.g. RFC 1812) are used instead.
+    let broadcast: [net::SocketAddr; 5] = [
+        // First of all, we try to determine the address of our machine under which it is
+        // known to other machines on our LAN. This is the most usable case because it can
+        // be used for multiplayer, as well as it should behave as localhost for ourselves.
+        ([192,168,255,255], port).into(),  // class C private: 192.168.0.0/16
+        ([172,31,255,255], port).into(),  // class B private: 172.16.0.0/12
+        ([10,255,255,255], port).into(),  // class A private: 10.0.0.0/8
+
+        // See 'INADDR_BROADCAST'. This also handles the virtual network adapters such as
+        // ones from VMWare / VirtualBox to imitate the IP lookup based on gethostbyname().
+        ([255,255,255,255], port).into(),  // limited broadcast: 255.255.255.255/32
+
+        // If all the previous effort has failed (which is pretty unlikely scenario), we
+        // give up and try to obtain at least the correct loopback address of this cursed
+        // machine. It almost never differs from the common 127.0.0.1, but in theory it is
+        // possible, and if we have already got to this place, anything can happen.
+        ([127,255,255,255], port).into(),  // host loopback: 127.0.0.0/8
+    ];
+
+    // Note that there are no real 'connections' in UDP, so what .connect() actually does
+    // is a statement to the network driver about the destination address to be used.
+    match socket.connect(&broadcast[..]).and_then(|_| socket.local_addr()) {
+        Ok(address) => Ok(address.ip()),
+        Err(e) => Err(e),
+    }
+}


### PR DESCRIPTION
This is the initial groundwork for a future implementation of `mplay_*` functions from GM.
Unlike the rest of the API, `mplay_ipaddress()` was used much more often, even in 39DLL games, as it allowed folks to get their LAN IP address. To be clear, 39DLL had a similar call for this: `hostip(myhost())`.

Some implementation details are worth noting.

As far as I understood from experiments, the original function, **assuming normal OS settings**, sequentially tries to return the first address from the following groups of addresses, in the order of the priority (metric) set in the network settings:

1. Machine addresses in local networks, starting with the default adapter.
2. Addresses of other network interfaces, for example virtual adapters of such hypervisors as VMware or VirtualBox.
3. Loopback address. At least one should always exist, in theory.

There are the following approaches to achieve similar behavior:

**1. Call `gethostname()` followed by `gethostbyname()`.**

This is the most common, and is used by GM itself. However, it has the following disadvantages.
Firstly, this approach requires a _properly configured_ DNS, and the name resolution can be slow.
Even the official help warns about it:

> **`mplay_ipaddress()`** returns the IP address of your machine (e.g. '123.123.123.12') as a string. You can e.g. display this somewhere on the screen. Note that this routine is slow so don't call it all the time.

Secondly, there is no cross-platform API in Rust for getting the hostname, since the `std::net::lookup_host()` function was [deprecated](https://github.com/rust-lang/rust/pull/47510) (unlike `std::net::lookup_addr()` that was moved to the `ToSocketAddrs` trait), which implies the need to access the OS API or use a third-party crate.

**2. Enumerate network adapters using the OS API.**

In Windows there's `GetAdaptersAddresses()` and `GetAdaptersInfo()` functions, while in *nix it's implemented by `getifsaddrs()` and/or `ioctl()` with `SIOCGIFADDR`. But all of this is completely unportable and will require an additional effort to support. Moreover, the proper adapter should be selected manually from the result.

**3. Bind a UDP socket to all network adapters and then probe every broadcasting address on the intended LAN.**

Proposed by this PR. This seems to be the most portable and straightforward solution, but it requires some verification on different platforms. By "intended LAN" the IANA address ranges reserved for private use are meant, ordered by ascending number of addresses.

This implementation works as intended on Windows 7, but also should be tested on Linux and macOS.
Unfortunately, currently I have neither one nor the other, nor a proper virtual machine, so I'm asking for help with it.