### PR TITLE
Fix for AtlasRef getter in sprites

### DIFF
--- a/gm8emulator/src/asset/sprite.rs
+++ b/gm8emulator/src/asset/sprite.rs
@@ -268,3 +268,25 @@ pub fn scale(input: &mut RgbaImage, width: u32, height: u32) {
         *input = RgbaImage::from_vec(width, height, output_vec).unwrap();
     }
 }
+
+impl Sprite {
+    fn get_image_index(&self, image_index: Real) -> Option<usize> {
+        (image_index.floor().into_inner() as isize).checked_rem_euclid(self.frames.len() as isize).map(|x| {x as usize})
+    }
+
+    pub fn get_frame(&self, image_index: Real) -> Option<&Frame> {
+        if let Some(image_index) = self.get_image_index(image_index) {
+            self.frames.get(image_index)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_atlas_ref(&self, image_index: Real) -> Option<&AtlasRef> {
+        if let Some(image_index) = self.get_image_index(image_index) {
+            self.frames.get(image_index).map(|x| &x.atlas_ref)
+        } else {
+            None
+        }
+    }
+}

--- a/gm8emulator/src/asset/sprite.rs
+++ b/gm8emulator/src/asset/sprite.rs
@@ -271,14 +271,13 @@ pub fn scale(input: &mut RgbaImage, width: u32, height: u32) {
 
 impl Sprite {
     fn get_image_index(&self, image_index: Real) -> Option<usize> {
-        (image_index.floor().into_inner() as isize).checked_rem_euclid(self.frames.len() as isize).map(|x| {x as usize})
+        (image_index.floor().into_inner() as isize).checked_rem_euclid(self.frames.len() as isize).map(|x| x as usize)
     }
 
     pub fn get_frame(&self, image_index: Real) -> Option<&Frame> {
-        if let Some(image_index) = self.get_image_index(image_index) {
-            self.frames.get(image_index)
-        } else {
-            None
+        match self.get_image_index(image_index) {
+            Some(image_index) => self.frames.get(image_index),
+            None => None,
         }
     }
 

--- a/gm8emulator/src/game/draw.rs
+++ b/gm8emulator/src/game/draw.rs
@@ -411,17 +411,10 @@ impl Game {
         self.renderer.set_depth(-13000.0);
         if let Some(sprite) = self.assets.sprites.get_asset(self.cursor_sprite) {
             let (x, y) = self.get_mouse_in_room();
-            if let Some(atlas_ref) = sprite.get_atlas_ref(Real::from(self.cursor_sprite_frame % sprite.frames.len() as u32)) {
-                self.renderer.draw_sprite(
-                    atlas_ref,
-                    x.into(),
-                    y.into(),
-                    1.0,
-                    1.0,
-                    0.0,
-                    0xffffff,
-                    1.0,
-                );
+            if let Some(atlas_ref) =
+                sprite.get_atlas_ref(Real::from(self.cursor_sprite_frame % sprite.frames.len() as u32))
+            {
+                self.renderer.draw_sprite(atlas_ref, x.into(), y.into(), 1.0, 1.0, 0.0, 0xffffff, 1.0);
             }
         }
 

--- a/gm8emulator/src/game/draw.rs
+++ b/gm8emulator/src/game/draw.rs
@@ -268,22 +268,18 @@ impl Game {
                 } else {
                     // Default draw action
                     if let Some(Some(sprite)) = game.assets.sprites.get(instance.sprite_index.get() as usize) {
-                        let image_index = (instance.image_index.get().floor().into_inner() as i32)
-                            .rem_euclid(sprite.frames.len() as i32);
-                        let atlas_ref = match sprite.frames.get(image_index as usize) {
-                            Some(f1) => &f1.atlas_ref,
-                            None => return Ok(()), // sprite with 0 frames?
-                        };
-                        game.renderer.draw_sprite(
-                            atlas_ref,
-                            instance.x.get().into(),
-                            instance.y.get().into(),
-                            instance.image_xscale.get().into(),
-                            instance.image_yscale.get().into(),
-                            instance.image_angle.get().into(),
-                            instance.image_blend.get(),
-                            instance.image_alpha.get().into(),
-                        )
+                        if let Some(atlas_ref) = sprite.get_atlas_ref(instance.image_index.get()) {
+                            game.renderer.draw_sprite(
+                                atlas_ref,
+                                instance.x.get().into(),
+                                instance.y.get().into(),
+                                instance.image_xscale.get().into(),
+                                instance.image_yscale.get().into(),
+                                instance.image_angle.get().into(),
+                                instance.image_blend.get(),
+                                instance.image_alpha.get().into(),
+                            )
+                        }
                     }
                     Ok(())
                 }
@@ -415,16 +411,18 @@ impl Game {
         self.renderer.set_depth(-13000.0);
         if let Some(sprite) = self.assets.sprites.get_asset(self.cursor_sprite) {
             let (x, y) = self.get_mouse_in_room();
-            self.renderer.draw_sprite(
-                &sprite.frames[self.cursor_sprite_frame as usize % sprite.frames.len()].atlas_ref,
-                x.into(),
-                y.into(),
-                1.0,
-                1.0,
-                0.0,
-                0xffffff,
-                1.0,
-            );
+            if let Some(atlas_ref) = sprite.get_atlas_ref(Real::from(self.cursor_sprite_frame % sprite.frames.len() as u32)) {
+                self.renderer.draw_sprite(
+                    atlas_ref,
+                    x.into(),
+                    y.into(),
+                    1.0,
+                    1.0,
+                    0.0,
+                    0xffffff,
+                    1.0,
+                );
+            }
         }
 
         Ok(())

--- a/gm8emulator/src/game/particle.rs
+++ b/gm8emulator/src/game/particle.rs
@@ -1431,7 +1431,7 @@ impl Particle {
                     }
                 }
                 if let Some(sprite) = assets.sprites.get_asset(sprite) {
-                    sprite.frames.get((subimage % sprite.frames.len() as i32) as usize).map(|x| &x.atlas_ref)
+                    sprite.get_atlas_ref(Real::from(subimage % sprite.frames.len() as i32))
                 } else {
                     None
                 }

--- a/gm8emulator/src/gml/kernel.rs
+++ b/gm8emulator/src/gml/kernel.rs
@@ -915,7 +915,7 @@ impl Game {
         let (sprite_index, image_index) = expect_args!(args, [int, int])?;
         if let Some(sprite) = self.assets.sprites.get_asset(sprite_index) {
             if let Some(atlas_ref) = sprite.get_atlas_ref(Real::from(image_index)) {
-                return Ok(self.renderer.get_texture_id(atlas_ref).into());
+                return Ok(self.renderer.get_texture_id(atlas_ref).into())
             }
             Ok((-1).into())
         } else {


### PR DESCRIPTION
Extracted duplicated code under single method implemented in Sprite, fixed issue with rem_euclid panicking.