### PR TITLE
Fix arg validation in emulated resize_backbuffer

### DIFF
--- a/gm8emulator/src/game/external/emulated/gm82core.rs
+++ b/gm8emulator/src/game/external/emulated/gm82core.rs
@@ -1,13 +1,16 @@
 use super::FunctionMap;
 use crate::{
     game::Game,
-    gml::{Function, Result, Value},
+    gml::{runtime, Function, Result, Value},
 };
 use phf::phf_map;
 
 pub fn resize_backbuffer(game: &mut Game, args: &[Value]) -> Result<Value> {
-    let width = args[0].clone().into();
-    let height = args[1].clone().into();
+    if args.len() != 2 {
+        return Err(runtime::Error::WrongArgumentCount(2, args.len()))
+    }
+    let width: u32 = args[0].clone().into();
+    let height: u32 = args[1].clone().into();
     game.renderer.resize_framebuffer(width, height, false);
     Ok(Default::default())
 }


### PR DESCRIPTION
## Summary
- Adds argument count validation to the emulated `resize_backbuffer` function in `gm82core.rs`
- Previously, calling with wrong arg count would panic on array index out of bounds
- Now returns a proper `WrongArgumentCount` error, consistent with how kernel functions validate args via `expect_args!`
- Adds explicit `u32` type annotations to clarify the `Value` conversion path

## Test plan
- [ ] Verify games using gm82core `resize_backbuffer` still work correctly
- [ ] Verify wrong arg count produces a clean error instead of a panic
