### PR TITLE
correctly record frames during restart

### DIFF
--- a/gm8emulator/src/game.rs
+++ b/gm8emulator/src/game.rs
@@ -1738,6 +1738,7 @@ impl Game {
 
         // Run room start event for each instance
         self.run_other_event(4)?;
+
         if self.play_type != PlayType::Record {
             let w: i32 = self.window_inner_size.0.try_into().unwrap();
             let h: i32 = self.window_inner_size.1.try_into().unwrap();
@@ -1753,6 +1754,7 @@ impl Game {
                     .unwrap();
             }
         }
+
         if self.scene_change.is_some() {
             // GM8 would have a memory leak here. We're not doing that.
             if let Some(surf) = self.surfaces.remove(trans_surf_old) {

--- a/gm8emulator/src/game.rs
+++ b/gm8emulator/src/game.rs
@@ -1738,7 +1738,21 @@ impl Game {
 
         // Run room start event for each instance
         self.run_other_event(4)?;
-
+        if self.play_type != PlayType::Record {
+            let w: i32 = self.window_inner_size.0.try_into().unwrap();
+            let h: i32 = self.window_inner_size.1.try_into().unwrap();
+            let pixels = self.renderer.get_pixels(0, 0, w, h);
+            if self.ffmpeg_recorder.is_some() {
+                self.ffmpeg_recorder
+                    .as_mut()
+                    .unwrap()
+                    .stdin
+                    .as_mut()
+                    .expect("Failed to open stdin")
+                    .write_all(&pixels)
+                    .unwrap();
+            }
+        }
         if self.scene_change.is_some() {
             // GM8 would have a memory leak here. We're not doing that.
             if let Some(surf) = self.surfaces.remove(trans_surf_old) {
@@ -1751,21 +1765,6 @@ impl Game {
             // Let then next frame handle it
             Ok(())
         } else {
-            if self.play_type != PlayType::Record {
-                let w: i32 = self.window_inner_size.0.try_into().unwrap();
-                let h: i32 = self.window_inner_size.1.try_into().unwrap();
-                let pixels = self.renderer.get_pixels(0, 0, w, h);
-                if self.ffmpeg_recorder.is_some() {
-                    self.ffmpeg_recorder
-                        .as_mut()
-                        .unwrap()
-                        .stdin
-                        .as_mut()
-                        .expect("Failed to open stdin")
-                        .write_all(&pixels)
-                        .unwrap();
-                }
-            }
             // Draw "frame 0", perform transition if applicable, and then return
             if self.auto_draw {
                 self.draw()?;


### PR DESCRIPTION
When tasing a game with a lot of restarts, nameless noticed that the recording was desyncing. We determined that the recorder was not recording frames that it should have been. With this change his newest tas syncs.